### PR TITLE
7 invalid inject

### DIFF
--- a/dingo.go
+++ b/dingo.go
@@ -15,6 +15,7 @@ const (
 	DEFAULT
 )
 
+var ErrInvalidInjectReceiver = errors.New("usage of 'Inject' method with struct receiver is not allowed")
 var traceCircular []circularTraceEntry
 
 // EnableCircularTracing activates dingo's trace feature to find circular dependencies
@@ -692,6 +693,10 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 		ctype := current.Type()
 
 		i++
+
+		if ctype.Kind() != reflect.Ptr && current.MethodByName("Inject").IsValid() {
+			return fmt.Errorf("invalid inject receiver %s: %w", current, ErrInvalidInjectReceiver)
+		}
 
 		switch ctype.Kind() {
 		// dereference pointer

--- a/dingo_test.go
+++ b/dingo_test.go
@@ -313,3 +313,25 @@ func TestInjector_InitModules(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Error(t, injector.InitModules(new(testInjectInvalid)))
 }
+
+type TestInjectStructRecInterface interface {
+	TestXyz()
+}
+
+type testInjectStructRecStruct struct{}
+
+func (t testInjectStructRecStruct) TestXyz() {}
+
+func (t testInjectStructRecStruct) Inject() {}
+
+func TestInjectStructRec(t *testing.T) {
+	t.Parallel()
+
+	injector, err := NewInjector()
+	assert.NoError(t, err)
+
+	injector.Bind(new(TestInjectStructRecInterface)).To(new(testInjectStructRecStruct))
+
+	_, err = injector.GetInstance(new(TestInjectStructRecInterface))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Added a test case for the issue and started with first approach to detect struct receivers by comparing the instance with an empty instance. It seems not to be possible to find out struct receivers using reflection. 

Current solution is not working for cases with struts that have no fields. See failing test cases...