### PR TITLE
feat: add module graph for dependency resolution and cycle detection

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,14 +15,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.*
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.11
           only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.*
+          go-version: 1.26
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26
+          go-version: '1.*'
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.25', '1.*' ]
+        go: [ '1.25', '1.26' ]
     name: Tests
     steps:
       - uses: actions/checkout@v6
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.*' ]
+        go: [ '1.26' ]
     name: Coverage Report
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.*' ]
+        go: [ '1.26' ]
     name: Static checks
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23', '1.*' ]
+        go: [ '1.25', '1.*' ]
     name: Tests
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Get dependencies
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Get dependencies
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Get dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.25', '1.26' ]
+        go: [ '1.25', '1.*' ]
     name: Tests
     steps:
       - uses: actions/checkout@v6
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.26' ]
+        go: [ '1.*' ]
     name: Coverage Report
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.26' ]
+        go: [ '1.*' ]
     name: Static checks
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,12 +55,6 @@ jobs:
           indicators: true
           output: both
           thresholds: '50 75'
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v3.0.4
-        if: github.event_name == 'pull_request'
-        with:
-          recreate: true
-          path: code-coverage-results.md
   static-checks:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/semanticore.yml
+++ b/.github/workflows/semanticore.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Semanticore

--- a/.github/workflows/semanticore.yml
+++ b/.github/workflows/semanticore.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.*' ]
+        go: [ '1.26' ]
     name: Semanticore
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/semanticore.yml
+++ b/.github/workflows/semanticore.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.26' ]
+        go: [ '1.*' ]
     name: Semanticore
     steps:
       - uses: actions/checkout@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,7 @@ linters:
     - usetesting
     - varnamelen
     - wrapcheck
-    - wsl
+    - wsl_v5
   settings:
     mnd:
       ignored-functions:
@@ -82,6 +82,10 @@ linters:
       ignore-chan-recv-ok: true
       ignore-decls:
         - i int
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 4
   exclusions:
     generated: lax
     presets:

--- a/dingo.go
+++ b/dingo.go
@@ -16,8 +16,9 @@ const (
 )
 
 var (
+	ErrInitModules           = errors.New("initialization of modules failed")
 	ErrInvalidInjectReceiver = errors.New("usage of 'Inject' method with struct receiver is not allowed")
-	errPointersToInterface   = errors.New(" Do not use pointers to interface.")
+	errPointersToInterface   = errors.New(" Do not use pointers to interface")
 
 	traceCircular    []circularTraceEntry
 	injectionTracing = false
@@ -46,7 +47,7 @@ type (
 		scopes               map[reflect.Type]Scope               // scope-bindings
 		stage                uint                                 // current stage
 		delayed              []interface{}                        // delayed bindings
-		buildEagerSingletons bool                                 // weather to build singletons
+		buildEagerSingletons bool                                 // whether to build singletons
 	}
 
 	// overrides are evaluated lazy, so they are scheduled here
@@ -107,7 +108,18 @@ func (injector *Injector) Child() (*Injector, error) {
 func (injector *Injector) InitModules(modules ...Module) error {
 	injector.stage = INIT
 
-	modules = resolveDependencies(modules, nil)
+	mg := newModuleGraph()
+
+	err := mg.Add(modules...)
+	if err != nil {
+		return fmt.Errorf("%w: failed adding modules to the graph: %w", ErrInitModules, err)
+	}
+
+	modules, err = mg.Sort()
+	if err != nil {
+		return fmt.Errorf("%w: failed sorting modules: %w", ErrInitModules, err)
+	}
+
 	for _, module := range modules {
 		if err := injector.requestInjection(module, traceCircular); err != nil {
 			erroredModule := reflect.TypeOf(module).Elem()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module flamingo.me/dingo
 
-go 1.26
+go 1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module flamingo.me/dingo
 
-go 1.23
+go 1.26
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	gonum.org/v1/gonum v0.17.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/module.go
+++ b/module.go
@@ -1,21 +1,28 @@
 package dingo
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
+	"slices"
+	"strings"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/topo"
 )
 
 type (
-	// Module is default entry point for dingo Modules.
+	// Module is the default entry point for dingo Modules.
 	// The Configure method is called once during initialization
-	// and let's the module setup Bindings for the provided Injector.
+	// and lets the module set up Bindings for the provided Injector.
 	Module interface {
 		Configure(injector *Injector)
 	}
 
 	// ModuleFunc wraps a func(injector *Injector) for dependency injection.
 	// This allows using small functions as dingo Modules.
-	// The same concept is http.HandlerFunc for http.Handler.
+	// It follows the same pattern as http.HandlerFunc for http.Handler.
 	ModuleFunc func(injector *Injector)
 
 	// Depender returns a list of Modules via the Depends method.
@@ -24,6 +31,24 @@ type (
 		Depends() []Module
 	}
 )
+
+var (
+	ErrModuleCycle = errors.New("cyclic module dependency")
+	ErrModuleSort  = errors.New("cannot sort modules")
+)
+
+// modGraph is a directed dependency graph of Modules.
+//
+// Edge direction: an edge A → B means "A must be initialized before B"
+// (A is a dependency of B). Cycles are therefore detected as strongly
+// connected components with more than one node.
+type modGraph struct {
+	*simple.DirectedGraph
+	idMap map[int64]Module // node ID → Module
+	index map[string]int64 // moduleIdentity → node ID
+}
+
+var typeOfModuleFunc = reflect.TypeOf(ModuleFunc(nil))
 
 // Configure call the original ModuleFunc with the given *Injector.
 func (f ModuleFunc) Configure(injector *Injector) {
@@ -50,31 +75,119 @@ func TryModule(modules ...Module) (resultingError error) {
 	return injector.InitModules(modules...)
 }
 
-var typeOfModuleFunc = reflect.TypeOf(ModuleFunc(nil))
-
-// resolveDependencies tries to get a complete list of all modules, including all dependencies
-// known can be empty initially, and will then be used for subsequent recursive calls
-func resolveDependencies(modules []Module, known map[interface{}]struct{}) []Module {
-	final := make([]Module, 0, len(modules))
-
-	if known == nil {
-		known = make(map[interface{}]struct{})
+// newModuleGraph returns an empty module dependency graph.
+func newModuleGraph() *modGraph {
+	mg := &modGraph{
+		DirectedGraph: simple.NewDirectedGraph(),
+		idMap:         make(map[int64]Module),
+		index:         make(map[string]int64),
 	}
 
+	return mg
+}
+
+// Add adds each module and its transitive dependencies to the graph.
+// A module that is already present (identified by its type or by a pointer
+// for ModuleFunc) is skipped — only the first instance is kept.
+func (mg *modGraph) Add(modules ...Module) error {
 	for _, module := range modules {
-		var identity interface{} = reflect.TypeOf(module)
-		if identity == typeOfModuleFunc {
-			identity = reflect.ValueOf(module)
+		_, err := mg.addModule(module)
+		if err != nil {
+			return err
 		}
-		if _, ok := known[identity]; ok {
-			continue
-		}
-		known[identity] = struct{}{}
-		if depender, ok := module.(Depender); ok {
-			final = append(final, resolveDependencies(depender.Depends(), known)...)
-		}
-		final = append(final, module)
 	}
 
-	return final
+	return nil
+}
+
+// Sort returns all modules in topological order: every dependency appears
+// before the modules that depend on it. Module identity
+// breaks ties between independent modules alphabetically, so the result is stable.
+// An error is returned if the graph contains a cycle.
+func (mg *modGraph) Sort() ([]Module, error) {
+	sorted, err := topo.SortStabilized(mg, mg.orderByName)
+	if err == nil {
+		modules := make([]Module, len(sorted))
+
+		for i, node := range sorted {
+			modules[i] = mg.idMap[node.ID()]
+		}
+
+		return modules, nil
+	}
+
+	if cycles, ok := errors.AsType[topo.Unorderable](err); ok && len(cycles) > 0 {
+		var names []string
+
+		for _, cycle := range cycles {
+			for _, node := range cycle {
+				if m, found := mg.idMap[node.ID()]; found {
+					names = append(names, moduleIdentity(m))
+				}
+			}
+
+			return nil, fmt.Errorf("%w: %s", ErrModuleCycle, strings.Join(names, " → ")) //nolint:staticcheck // return just the first cycle
+		}
+	}
+
+	return nil, ErrModuleSort
+}
+
+// orderByName is the tiebreaker passed to topo.SortStabilized.
+// It sorts a batch of topologically equivalent nodes alphabetically
+// by module identity so that Sort produces a deterministic result.
+func (mg *modGraph) orderByName(nodes []graph.Node) {
+	slices.SortStableFunc(nodes, func(a, b graph.Node) int {
+		m1 := mg.idMap[a.ID()]
+		m2 := mg.idMap[b.ID()]
+
+		return strings.Compare(moduleIdentity(m1), moduleIdentity(m2))
+	})
+}
+
+// addModule inserts a single module into the graph (if not already present)
+// and recursively inserts all modules returned by its Depends method.
+// It returns the graph node ID assigned to the module.
+func (mg *modGraph) addModule(module Module) (int64, error) {
+	key := moduleIdentity(module)
+
+	processed, ok := mg.index[key]
+	if ok {
+		return processed, nil
+	}
+
+	newNode := mg.NewNode()
+	mg.index[key] = newNode.ID()
+	mg.idMap[newNode.ID()] = module
+	mg.AddNode(newNode)
+
+	if depender, ok := module.(Depender); ok {
+		for _, dep := range depender.Depends() {
+			depID, err := mg.addModule(dep)
+			if err != nil {
+				return 0, fmt.Errorf("could not add module: %w", err)
+			}
+
+			depNode := mg.Node(depID)
+			isDependencyOf := mg.NewEdge(depNode, newNode) // depNode is a dependency of newNode
+
+			mg.SetEdge(isDependencyOf)
+		}
+	}
+
+	return newNode.ID(), nil
+}
+
+// moduleIdentity returns a stable string key that uniquely identifies a module.
+// For ordinary module types the key is the fully qualified type name.
+// For ModuleFunc values the function pointer address is included so that
+// two distinct func literals are treated as different modules.
+func moduleIdentity(module Module) string {
+	modType := reflect.TypeOf(module)
+	if modType == typeOfModuleFunc {
+		value := reflect.ValueOf(module)
+		return fmt.Sprintf("%s_%d", value.Type(), value.Pointer())
+	}
+
+	return modType.String()
 }

--- a/module.go
+++ b/module.go
@@ -116,7 +116,12 @@ func (mg *modGraph) Sort() ([]Module, error) {
 		return modules, nil
 	}
 
-	if cycles, ok := errors.AsType[topo.Unorderable](err); ok && len(cycles) > 0 {
+	//TODO: uncomment once go1.27 is released (errors.AsType is available only since go1.26)
+	// if cycles, ok := errors.AsType[topo.Unorderable](err); ok && len(cycles) > 0 {
+
+	var cycles topo.Unorderable
+
+	if errors.As(err, &cycles) && len(cycles) > 0 {
 		var names []string
 
 		for _, cycle := range cycles {

--- a/module_test.go
+++ b/module_test.go
@@ -1,10 +1,10 @@
 package dingo
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type (
@@ -68,7 +68,6 @@ type (
 func (*resolveDependenciesModuleA) Configure(*Injector) {}
 func (*resolveDependenciesModuleA) Depends() []Module {
 	return []Module{
-		new(resolveDependenciesModuleA),
 		new(resolveDependenciesModuleB),
 		new(resolveDependenciesModuleB2),
 	}
@@ -84,14 +83,131 @@ func (*resolveDependenciesModuleB2) Configure(*Injector) {}
 func (*resolveDependenciesModuleC) Configure(*Injector)  {}
 
 func Test_resolveDependencies(t *testing.T) {
-	resolved := resolveDependencies([]Module{new(resolveDependenciesModuleA)}, nil)
+	mg := newModuleGraph()
+	err := mg.Add(new(resolveDependenciesModuleA))
+	require.NoError(t, err)
+	resolved, err := mg.Sort()
+	require.NoError(t, err)
 
-	if !reflect.DeepEqual(resolved, []Module{
-		new(resolveDependenciesModuleC),
+	assert.Equal(t, []Module{
 		new(resolveDependenciesModuleB2),
+		new(resolveDependenciesModuleC),
 		new(resolveDependenciesModuleB),
 		new(resolveDependenciesModuleA),
-	}) {
-		t.Errorf("%#v not correctly resolved", resolved)
+	}, resolved)
+}
+
+var (
+	_ Module = new(A)
+	_ Module = new(B)
+	_ Module = new(C)
+	_ Module = new(D)
+
+	_ Depender = new(A)
+	_ Depender = new(C)
+	_ Depender = new(E)
+)
+
+// Module Graph
+type (
+	A struct {
+		withCycle   bool
+		SampleText1 string `inject:"test1"`
 	}
+	B struct{}
+	C struct{ withCycle bool }
+	D struct{}
+	E struct {
+		SampleText2 string `inject:"test2"`
+	}
+)
+
+func (a *A) Configure(i *Injector) {
+	i.Bind(new(string)).AnnotatedWith("test2").ToInstance("test2")
+}
+
+func (b *B) Configure(i *Injector) {
+	i.Bind(new(string)).AnnotatedWith("test1").ToInstance("test1")
+}
+
+func (c *C) Configure(_ *Injector) {
+}
+
+func (d *D) Configure(_ *Injector) {
+}
+
+func (e *E) Configure(_ *Injector) {
+}
+
+func (a *A) Depends() []Module {
+	return []Module{new(B), &C{withCycle: a.withCycle}}
+}
+
+func (c *C) Depends() []Module {
+	deps := []Module{
+		new(B),
+		new(D),
+	}
+
+	if c.withCycle {
+		deps = append(deps, new(E))
+	}
+
+	return deps
+}
+
+func (e *E) Depends() []Module {
+	return []Module{new(A)}
+}
+
+func TestModGraph_Sorted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modules   []Module
+		sorted    []Module
+		assertErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:      "no cycle",
+			modules:   []Module{&A{withCycle: false}, new(B), &C{withCycle: false}, new(D), new(E)},
+			sorted:    []Module{new(B), new(D), &C{withCycle: false}, &A{withCycle: false}, new(E)},
+			assertErr: assert.NoError,
+		},
+		{
+			name:    "cycle A→C→E→A",
+			modules: []Module{&A{withCycle: true}, new(B), new(D), new(E)},
+			assertErr: assert.ErrorAssertionFunc(func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, ErrModuleCycle) &&
+					assert.ErrorContains(t, err, "cyclic module dependency: *dingo.A → *dingo.C → *dingo.E")
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mg := newModuleGraph()
+			err := mg.Add(test.modules...)
+			require.NoError(t, err)
+
+			sorted, err := mg.Sort()
+			if test.assertErr(t, err) {
+				assert.Equalf(t, test.sorted, sorted, "Sorted()")
+			}
+		})
+	}
+}
+
+func TestWithInjector(t *testing.T) {
+	t.Parallel()
+
+	injector, err := NewInjector()
+	require.NoError(t, err)
+
+	modules := []Module{new(E), new(D), new(C), new(B), new(A)}
+
+	err = injector.InitModules(modules...)
+	assert.NoError(t, err)
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -81,7 +81,9 @@ type (
 )
 
 func TestScopeWithSubDependencies(t *testing.T) {
-	scp := new(singletonC("singleton C"))
+	sc := singletonC("singleton C")
+	scp := &sc
+
 	for i := 0; i < 10; i++ {
 		t.Run(fmt.Sprintf("Run %d", i), func(t *testing.T) {
 			injector, err := NewInjector()

--- a/scope_test.go
+++ b/scope_test.go
@@ -81,8 +81,7 @@ type (
 )
 
 func TestScopeWithSubDependencies(t *testing.T) {
-	sc := singletonC("singleton C")
-	scp := &sc
+	scp := new(singletonC("singleton C"))
 	for i := 0; i < 10; i++ {
 		t.Run(fmt.Sprintf("Run %d", i), func(t *testing.T) {
 			injector, err := NewInjector()


### PR DESCRIPTION
### feat: replace recursive dependency resolution with topological graph sort

#### Summary

Replaces the ad-hoc recursive `resolveDependencies` function with a directed acyclic graph (DAG) for module dependency resolution. Modules are now sorted via `gonum/graph/topo`, which ensures a deterministic initialization order and provides cycle detection with error messages.

---

#### Motivation

The `resolveDependencies()` function gave no ordering guarantees and ignored cycles.

---

#### Breaking changes

None. `ErrInitModules`, `ErrModuleCycle`, and `ErrModuleSort` are added to the public API. The initialization order of previously unordered peer modules may change (now alphabetically stable).
