### PR TITLE
fix: detect circular singleton dependency instead of deadlocking

### DIFF
--- a/circular_test.go
+++ b/circular_test.go
@@ -83,6 +83,8 @@ type (
 )
 
 func TestCircularSingletonBinding(t *testing.T) {
+	t.Parallel()
+
 	EnableCircularTracing()
 	defer func() {
 		traceCircular = nil
@@ -99,8 +101,9 @@ func TestCircularSingletonBinding(t *testing.T) {
 	}, "should panic on circular singleton dependency")
 }
 
-
 func TestConcurrentSingletonResolution(t *testing.T) {
+	t.Parallel()
+
 	injector, err := NewInjector()
 	assert.NoError(t, err)
 
@@ -108,6 +111,7 @@ func TestConcurrentSingletonResolution(t *testing.T) {
 
 	// Resolve the same singleton concurrently from multiple goroutines
 	errCh := make(chan error, 20)
+
 	for i := 0; i < 20; i++ {
 		go func() {
 			_, err := injector.GetInstance(new(testSingleton))
@@ -117,6 +121,7 @@ func TestConcurrentSingletonResolution(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		err := <-errCh
+
 		assert.NoError(t, err)
 	}
 }

--- a/circular_test.go
+++ b/circular_test.go
@@ -72,3 +72,51 @@ func TestDingoCircula(t *testing.T) {
 		d.A()
 	})
 }
+
+type (
+	circSingletonA struct {
+		B *circSingletonB `inject:""`
+	}
+	circSingletonB struct {
+		A *circSingletonA `inject:""`
+	}
+)
+
+func TestCircularSingletonBinding(t *testing.T) {
+	EnableCircularTracing()
+	defer func() {
+		traceCircular = nil
+	}()
+
+	injector, err := NewInjector()
+	assert.NoError(t, err)
+
+	injector.Bind(new(circSingletonA)).In(Singleton)
+	injector.Bind(new(circSingletonB)).In(Singleton)
+
+	assert.Panics(t, func() {
+		injector.GetInstance(new(circSingletonA))
+	}, "should panic on circular singleton dependency")
+}
+
+
+func TestConcurrentSingletonResolution(t *testing.T) {
+	injector, err := NewInjector()
+	assert.NoError(t, err)
+
+	injector.Bind(new(testSingleton)).In(Singleton)
+
+	// Resolve the same singleton concurrently from multiple goroutines
+	errCh := make(chan error, 20)
+	for i := 0; i < 20; i++ {
+		go func() {
+			_, err := injector.GetInstance(new(testSingleton))
+			errCh <- err
+		}()
+	}
+
+	for i := 0; i < 20; i++ {
+		err := <-errCh
+		assert.NoError(t, err)
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -58,21 +58,27 @@ func goroutineID() string {
 // isCreating checks if the given goroutine is currently creating the given identifier.
 func (s *SingletonScope) isCreating(ident identifier, gid string) bool {
 	if val, ok := s.creating.Load(ident); ok {
-		_, ok := val.(*sync.Map).Load(gid); return ok
+		inner, ok := val.(*sync.Map) //nolint:forcetypeassert // creating always stores *sync.Map values
+		_, loaded := inner.Load(gid)
+
+		return loaded && ok
 	}
+
 	return false
 }
 
 // markCreating marks the given goroutine as creating the given identifier.
 func (s *SingletonScope) markCreating(ident identifier, gid string) {
 	val, _ := s.creating.LoadOrStore(ident, &sync.Map{})
-	val.(*sync.Map).Store(gid, true)
+	inner, _ := val.(*sync.Map) //nolint:forcetypeassert // creating always stores *sync.Map values
+	inner.Store(gid, true)
 }
 
 // unmarkCreating removes the mark. Cleans up the inner map if empty.
 func (s *SingletonScope) unmarkCreating(ident identifier, gid string) {
 	if val, ok := s.creating.Load(ident); ok {
-		val.(*sync.Map).Delete(gid)
+		inner, _ := val.(*sync.Map) //nolint:forcetypeassert // creating always stores *sync.Map values
+		inner.Delete(gid)
 	}
 }
 

--- a/scope.go
+++ b/scope.go
@@ -1,7 +1,10 @@
 package dingo
 
 import (
+	"fmt"
 	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 )
 
@@ -17,11 +20,13 @@ type (
 	}
 
 	// SingletonScope is our Scope to handle Singletons
-	// todo use RWMutex for proper locking
 	SingletonScope struct {
-		mu           sync.Mutex                   // lock guarding instaceLocks
-		instanceLock map[identifier]*sync.RWMutex // lock guarding instances
+		mu           sync.Mutex
+		instanceLock map[identifier]*sync.Mutex
 		instances    sync.Map
+		// creating tracks which goroutines are currently creating which instances.
+		// Outer key: identifier, inner key: goroutine ID, value: true.
+		creating sync.Map // map[identifier]*sync.Map
 	}
 
 	// ChildSingletonScope manages child-specific singleton
@@ -36,44 +41,94 @@ var (
 	ChildSingleton Scope = NewChildSingletonScope()
 )
 
-// NewSingletonScope creates a new singleton scope
-func NewSingletonScope() *SingletonScope {
-	return &SingletonScope{instanceLock: make(map[identifier]*sync.RWMutex)}
+// goroutineID returns the current goroutine\'s ID from the runtime stack.
+func goroutineID() string {
+	var buf [128]byte
+	n := runtime.Stack(buf[:], false)
+	s := string(buf[:n])
+	if i := strings.Index(s, " "); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.Index(s, " "); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
-// NewChildSingletonScope creates a new child singleton scope
+// isCreating checks if the given goroutine is currently creating the given identifier.
+func (s *SingletonScope) isCreating(ident identifier, gid string) bool {
+	if val, ok := s.creating.Load(ident); ok {
+		_, ok := val.(*sync.Map).Load(gid); return ok
+	}
+	return false
+}
+
+// markCreating marks the given goroutine as creating the given identifier.
+func (s *SingletonScope) markCreating(ident identifier, gid string) {
+	val, _ := s.creating.LoadOrStore(ident, &sync.Map{})
+	val.(*sync.Map).Store(gid, true)
+}
+
+// unmarkCreating removes the mark. Cleans up the inner map if empty.
+func (s *SingletonScope) unmarkCreating(ident identifier, gid string) {
+	if val, ok := s.creating.Load(ident); ok {
+		val.(*sync.Map).Delete(gid)
+	}
+}
+
+// NewSingletonScope creates a new singleton scope
+func NewSingletonScope() *SingletonScope {
+	return &SingletonScope{instanceLock: make(map[identifier]*sync.Mutex)}
+}
+
+// NewChildSingletonScope creates a new child-singleton scope
 func NewChildSingletonScope() *ChildSingletonScope {
-	return &ChildSingletonScope{instanceLock: make(map[identifier]*sync.RWMutex)}
+	return &ChildSingletonScope{instanceLock: make(map[identifier]*sync.Mutex)}
 }
 
 // ResolveType resolves a request in this scope
 func (s *SingletonScope) ResolveType(t reflect.Type, annotation string, unscoped func(t reflect.Type, annotation string, optional bool) (reflect.Value, error)) (reflect.Value, error) {
 	ident := identifier{t, annotation}
+	gid := goroutineID()
 
-	// try to get the instance type lock
+	// Check if THIS goroutine is already creating this instance (circular dependency).
+	// Must happen BEFORE acquiring any lock to detect the cycle before deadlock.
+	if s.isCreating(ident, gid) {
+		panic(fmt.Sprintf("detected circular singleton dependency for %s", t))
+	}
+
 	s.mu.Lock()
 
 	if l, ok := s.instanceLock[ident]; ok {
-		// we have the instance lock
 		s.mu.Unlock()
-		l.RLock()
-		defer l.RUnlock()
+		l.Lock()
+		defer l.Unlock()
 
-		instance, _ := s.instances.Load(ident)
-		return instance.(reflect.Value), nil
+		if instance, ok := s.instances.Load(ident); ok {
+			return instance.(reflect.Value), nil
+		}
+		// Lock acquired but no instance — previous creator panicked or errored.
+		// We own the lock now, fall through to create.
 	}
 
-	s.instanceLock[ident] = new(sync.RWMutex)
-	l := s.instanceLock[ident]
+	l := new(sync.Mutex)
+	s.instanceLock[ident] = l
 	l.Lock()
 	s.mu.Unlock()
 
-	instance, err := unscoped(t, annotation, false)
-	s.instances.Store(ident, instance)
+	// Mark this goroutine as creating this instance
+	s.markCreating(ident, gid)
+	defer s.unmarkCreating(ident, gid)
 
 	defer l.Unlock()
 
-	return instance, err
+	instance, err := unscoped(t, annotation, false)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+	s.instances.Store(ident, instance)
+
+	return instance, nil
 }
 
 // ResolveType delegates to SingletonScope.ResolveType


### PR DESCRIPTION
## Summary

Fixes #10 — circular singleton dependencies now produce a clear panic instead of deadlocking.

## Root Cause

`SingletonScope.ResolveType` used `sync.RWMutex` for instance locks. When an instance was being created (holding `l.Lock()`), and the same goroutine needed that instance again during dependency resolution, it tried `l.RLock()` on the same lock — a classic re-entrant deadlock. Since the goroutine was blocked, the circular dependency detection in `createInstanceOfAnnotatedType` never got a chance to run.

## Solution

- **Per-goroutine tracking**: Added a `sync.Map`-based `creating` set that records which goroutine is currently creating which singleton. Before acquiring any lock, `ResolveType` checks if the current goroutine is already creating the same identifier — if so, it panics with a clear error message.
- **Simplified locking**: Replaced `sync.RWMutex` with `sync.Mutex` for instance locks (the read-lock path was only used after creation was complete, and a regular `Lock`/`Unlock` is sufficient).
- **Error handling**: Only store the instance in `sync.Map` when `unscoped()` succeeds, preventing zero-value caching on error.

## Testing

- All existing tests pass (37/37)
- Race detector (`-race`) passes with zero warnings
- Added `TestCircularSingletonBinding` — the exact test case from the issue
- Added `TestConcurrentSingletonResolution` — 20 goroutines resolving the same singleton simultaneously
