### PR TITLE
fix: key modules by exact type and preserve same-name bindings

### DIFF
--- a/dingo.go
+++ b/dingo.go
@@ -725,7 +725,7 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 
 		i++
 
-		if ctype.Kind() != reflect.Pointer && current.MethodByName("Inject").IsValid() {
+		if ctype.Kind() != reflect.Ptr && current.MethodByName("Inject").IsValid() {
 			return fmt.Errorf("invalid inject receiver %s: %w", current, ErrInvalidInjectReceiver)
 		}
 
@@ -778,7 +778,7 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 
 						field.Set(instance.Elem())
 					} else {
-						if field.Kind() == reflect.Pointer && field.Type().Kind() == reflect.Pointer && field.Type().Elem().Kind() == reflect.Interface {
+						if field.Kind() == reflect.Ptr && field.Type().Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Interface {
 							return wrapErr(fmt.Errorf("field %#v is pointer to interface. %w", currentFieldName, errPointersToInterface))
 						}
 

--- a/dingo.go
+++ b/dingo.go
@@ -725,7 +725,7 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 
 		i++
 
-		if ctype.Kind() != reflect.Ptr && current.MethodByName("Inject").IsValid() {
+		if ctype.Kind() != reflect.Pointer && current.MethodByName("Inject").IsValid() {
 			return fmt.Errorf("invalid inject receiver %s: %w", current, ErrInvalidInjectReceiver)
 		}
 
@@ -778,7 +778,7 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 
 						field.Set(instance.Elem())
 					} else {
-						if field.Kind() == reflect.Ptr && field.Type().Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Interface {
+						if field.Kind() == reflect.Pointer && field.Type().Kind() == reflect.Pointer && field.Type().Elem().Kind() == reflect.Interface {
 							return wrapErr(fmt.Errorf("field %#v is pointer to interface. %w", currentFieldName, errPointersToInterface))
 						}
 

--- a/module.go
+++ b/module.go
@@ -50,8 +50,12 @@ type modGraph struct {
 }
 
 type moduleKey struct {
-	typ      reflect.Type
-	function uintptr
+	typ reflect.Type
+	// function identifies a ModuleFunc by the reflect.Value of the wrapped func.
+	// reflect.Value compares by the underlying func value, so closures created
+	// from the same func literal stay distinct — reflect.Value.Pointer would
+	// collapse them into their shared code pointer. It is nil for other modules.
+	function interface{}
 }
 
 var typeOfModuleFunc = reflect.TypeOf(ModuleFunc(nil))
@@ -207,13 +211,14 @@ func (mg *modGraph) addModule(order int, module Module) (int64, error) {
 
 // moduleKeyOf returns a comparable key that uniquely identifies a module.
 // Ordinary modules are keyed by reflect.Type. ModuleFunc values also include
-// their function pointer so distinct literals remain distinct.
+// the wrapped func value so that distinct funcs — including distinct closures
+// created from the same func literal — remain distinct modules.
 func moduleKeyOf(module Module) moduleKey {
 	modType := reflect.TypeOf(module)
 	key := moduleKey{typ: modType}
 
 	if modType == typeOfModuleFunc {
-		key.function = reflect.ValueOf(module).Pointer()
+		key.function = reflect.ValueOf(module)
 	}
 
 	return key
@@ -221,8 +226,8 @@ func moduleKeyOf(module Module) moduleKey {
 
 // name returns the display name used in module graph diagnostics.
 func (k moduleKey) name() string {
-	if k.typ == typeOfModuleFunc {
-		return fmt.Sprintf("%s_%d", qualifiedTypeName(k.typ), k.function)
+	if value, ok := k.function.(reflect.Value); ok {
+		return fmt.Sprintf("%s_%d", qualifiedTypeName(k.typ), value.Pointer())
 	}
 
 	return qualifiedTypeName(k.typ)

--- a/module.go
+++ b/module.go
@@ -200,10 +200,11 @@ func (mg *modGraph) addModule(order int, module Module) (int64, error) {
 	return newNode.ID(), nil
 }
 
-// moduleIdentity returns a stable string key that uniquely identifies a module.
-// For ordinary module types the key is the fully qualified type name.
-// For ModuleFunc values the function pointer address is included so that
-// two distinct func literals are treated as different modules.
+// moduleIdentity returns a stable key uniquely identifying a module. Ordinary
+// modules are keyed by their import-path-qualified type name; the full path
+// (not reflect.Type.String, which uses only the short package name) is needed
+// so same-named types from different packages don't collide. ModuleFunc values
+// are keyed by their function pointer so distinct literals stay distinct.
 func moduleIdentity(module Module) string {
 	modType := reflect.TypeOf(module)
 	if modType == typeOfModuleFunc {
@@ -211,5 +212,20 @@ func moduleIdentity(module Module) string {
 		return fmt.Sprintf("%s_%d", value.Type(), value.Pointer())
 	}
 
-	return modType.String()
+	return qualifiedTypeName(modType)
+}
+
+// qualifiedTypeName is like reflect.Type.String but uses the full import path
+// instead of the short package name, preserving pointer markers. Unnamed types
+// (no import path) fall back to String.
+func qualifiedTypeName(t reflect.Type) string {
+	if t.Kind() == reflect.Pointer {
+		return "*" + qualifiedTypeName(t.Elem())
+	}
+
+	if t.PkgPath() == "" {
+		return t.String()
+	}
+
+	return t.PkgPath() + "." + t.Name()
 }

--- a/module.go
+++ b/module.go
@@ -222,26 +222,49 @@ func moduleKeyOf(module Module) moduleKey {
 // name returns the display name used in module graph diagnostics.
 func (k moduleKey) name() string {
 	if k.typ == typeOfModuleFunc {
-		return fmt.Sprintf("%s_%d", k.typ, k.function)
+		return fmt.Sprintf("%s_%d", qualifiedTypeName(k.typ), k.function)
 	}
 
 	return qualifiedTypeName(k.typ)
 }
 
+// moduleName returns the display name used in module graph diagnostics for the given module.
 func moduleName(module Module) string {
 	return moduleKeyOf(module).name()
 }
 
 // qualifiedTypeName is like reflect.Type.String but uses the full import path
-// instead of the short package name, preserving pointer markers. Unnamed types
-// (no import path) fall back to String.
+// instead of the short package name for named types. It handles common
+// composite types recursively (pointer, slice, array, map, channel) so that
+// any named element/key type inside them is also fully qualified. Anonymous
+// composite types (struct, interface, func) fall back to reflect.Type.String,
+// as does anything else not covered above.
 func qualifiedTypeName(t reflect.Type) string {
 	if t.PkgPath() != "" {
 		return t.PkgPath() + "." + t.Name()
 	}
 
-	if t.Kind() == reflect.Pointer {
+	switch t.Kind() {
+	case reflect.Pointer:
 		return "*" + qualifiedTypeName(t.Elem())
+	case reflect.Slice:
+		return "[]" + qualifiedTypeName(t.Elem())
+	case reflect.Array:
+		return fmt.Sprintf("[%d]%s", t.Len(), qualifiedTypeName(t.Elem()))
+	case reflect.Map:
+		return "map[" + qualifiedTypeName(t.Key()) + "]" + qualifiedTypeName(t.Elem())
+	case reflect.Chan:
+		var prefix string
+		switch t.ChanDir() {
+		case reflect.RecvDir:
+			prefix = "<-chan "
+		case reflect.SendDir:
+			prefix = "chan<- "
+		default:
+			prefix = "chan "
+		}
+
+		return prefix + qualifiedTypeName(t.Elem())
 	}
 
 	return t.String()

--- a/module.go
+++ b/module.go
@@ -239,33 +239,35 @@ func moduleName(module Module) string {
 // any named element/key type inside them is also fully qualified. Anonymous
 // composite types (struct, interface, func) fall back to reflect.Type.String,
 // as does anything else not covered above.
-func qualifiedTypeName(t reflect.Type) string {
-	if t.PkgPath() != "" {
-		return t.PkgPath() + "." + t.Name()
+func qualifiedTypeName(typ reflect.Type) string {
+	if typ.PkgPath() != "" {
+		return typ.PkgPath() + "." + typ.Name()
 	}
 
-	switch t.Kind() {
+	//nolint:exhaustive // only kinds that can wrap a named type are qualified, everything else falls back to reflect.Type.String
+	switch typ.Kind() {
 	case reflect.Pointer:
-		return "*" + qualifiedTypeName(t.Elem())
+		return "*" + qualifiedTypeName(typ.Elem())
 	case reflect.Slice:
-		return "[]" + qualifiedTypeName(t.Elem())
+		return "[]" + qualifiedTypeName(typ.Elem())
 	case reflect.Array:
-		return fmt.Sprintf("[%d]%s", t.Len(), qualifiedTypeName(t.Elem()))
+		return fmt.Sprintf("[%d]%s", typ.Len(), qualifiedTypeName(typ.Elem()))
 	case reflect.Map:
-		return "map[" + qualifiedTypeName(t.Key()) + "]" + qualifiedTypeName(t.Elem())
+		return "map[" + qualifiedTypeName(typ.Key()) + "]" + qualifiedTypeName(typ.Elem())
 	case reflect.Chan:
 		var prefix string
-		switch t.ChanDir() {
+
+		switch typ.ChanDir() {
 		case reflect.RecvDir:
 			prefix = "<-chan "
 		case reflect.SendDir:
 			prefix = "chan<- "
-		default:
+		case reflect.BothDir:
 			prefix = "chan "
 		}
 
-		return prefix + qualifiedTypeName(t.Elem())
+		return prefix + qualifiedTypeName(typ.Elem())
 	}
 
-	return t.String()
+	return typ.String()
 }

--- a/module.go
+++ b/module.go
@@ -51,11 +51,10 @@ type modGraph struct {
 
 type moduleKey struct {
 	typ reflect.Type
-	// function identifies a ModuleFunc by the reflect.Value of the wrapped func.
-	// reflect.Value compares by the underlying func value, so closures created
-	// from the same func literal stay distinct — reflect.Value.Pointer would
-	// collapse them into their shared code pointer. It is nil for other modules.
-	function interface{}
+	// function preserves ModuleFunc value identity. Different closures can share
+	// a code pointer, so reflect.Value keeps them distinct as it did before the
+	// module graph was introduced. It is nil for other modules.
+	function any
 }
 
 var typeOfModuleFunc = reflect.TypeOf(ModuleFunc(nil))
@@ -98,7 +97,7 @@ func newModuleGraph() *modGraph {
 }
 
 // Add adds each module and its transitive dependencies to the graph.
-// A module that is already present (identified by its type or by a pointer
+// A module that is already present (identified by its type or function value
 // for ModuleFunc) is skipped — only the first instance is kept.
 func (mg *modGraph) Add(modules ...Module) error {
 	for i, module := range modules {

--- a/module.go
+++ b/module.go
@@ -44,9 +44,9 @@ var (
 // connected components with more than one node.
 type modGraph struct {
 	*simple.DirectedGraph
-	idMap map[int64]Module // node ID → Module
-	index map[moduleKey]int64
-	order map[int64]int // node ID → registration order (loop index from Add)
+	idMap map[int64]Module    // node ID → Module
+	index map[moduleKey]int64 // moduleKey → node ID
+	order map[int64]int       // node ID → registration order (loop index from Add)
 }
 
 type moduleKey struct {
@@ -175,7 +175,7 @@ func (mg *modGraph) orderByInsertion(nodes []graph.Node) {
 // the order from their first registration.
 // It returns the graph node ID assigned to the module.
 func (mg *modGraph) addModule(order int, module Module) (int64, error) {
-	key := moduleIdentity(module)
+	key := moduleKeyOf(module)
 
 	processed, ok := mg.index[key]
 	if ok {
@@ -205,12 +205,10 @@ func (mg *modGraph) addModule(order int, module Module) (int64, error) {
 	return newNode.ID(), nil
 }
 
-// moduleIdentity returns a comparable key that uniquely identifies a module.
-// Ordinary modules are keyed by reflect.Type, which preserves exact type
-// identity without relying on a potentially ambiguous string representation.
-// ModuleFunc values also include their function pointer so distinct literals
-// remain distinct.
-func moduleIdentity(module Module) moduleKey {
+// moduleKeyOf returns a comparable key that uniquely identifies a module.
+// Ordinary modules are keyed by reflect.Type. ModuleFunc values also include
+// their function pointer so distinct literals remain distinct.
+func moduleKeyOf(module Module) moduleKey {
 	modType := reflect.TypeOf(module)
 	key := moduleKey{typ: modType}
 
@@ -221,14 +219,17 @@ func moduleIdentity(module Module) moduleKey {
 	return key
 }
 
-// moduleName returns the display name used in module graph diagnostics.
-func moduleName(module Module) string {
-	key := moduleIdentity(module)
-	if key.typ == typeOfModuleFunc {
-		return fmt.Sprintf("%s_%d", key.typ, key.function)
+// name returns the display name used in module graph diagnostics.
+func (k moduleKey) name() string {
+	if k.typ == typeOfModuleFunc {
+		return fmt.Sprintf("%s_%d", k.typ, k.function)
 	}
 
-	return qualifiedTypeName(key.typ)
+	return qualifiedTypeName(k.typ)
+}
+
+func moduleName(module Module) string {
+	return moduleKeyOf(module).name()
 }
 
 // qualifiedTypeName is like reflect.Type.String but uses the full import path

--- a/module.go
+++ b/module.go
@@ -45,8 +45,13 @@ var (
 type modGraph struct {
 	*simple.DirectedGraph
 	idMap map[int64]Module // node ID → Module
-	index map[string]int64 // moduleIdentity → node ID
-	order map[int64]int    // node ID → registration order (loop index from Add)
+	index map[moduleKey]int64
+	order map[int64]int // node ID → registration order (loop index from Add)
+}
+
+type moduleKey struct {
+	typ      reflect.Type
+	function uintptr
 }
 
 var typeOfModuleFunc = reflect.TypeOf(ModuleFunc(nil))
@@ -81,7 +86,7 @@ func newModuleGraph() *modGraph {
 	mg := &modGraph{
 		DirectedGraph: simple.NewDirectedGraph(),
 		idMap:         make(map[int64]Module),
-		index:         make(map[string]int64),
+		index:         make(map[moduleKey]int64),
 		order:         make(map[int64]int),
 	}
 
@@ -131,7 +136,7 @@ func (mg *modGraph) Sort() ([]Module, error) {
 		for _, cycle := range cycles {
 			for _, node := range cycle {
 				if m, found := mg.idMap[node.ID()]; found {
-					names = append(names, moduleIdentity(m))
+					names = append(names, moduleName(m))
 				}
 			}
 
@@ -200,32 +205,43 @@ func (mg *modGraph) addModule(order int, module Module) (int64, error) {
 	return newNode.ID(), nil
 }
 
-// moduleIdentity returns a stable key uniquely identifying a module. Ordinary
-// modules are keyed by their import-path-qualified type name; the full path
-// (not reflect.Type.String, which uses only the short package name) is needed
-// so same-named types from different packages don't collide. ModuleFunc values
-// are keyed by their function pointer so distinct literals stay distinct.
-func moduleIdentity(module Module) string {
+// moduleIdentity returns a comparable key that uniquely identifies a module.
+// Ordinary modules are keyed by reflect.Type, which preserves exact type
+// identity without relying on a potentially ambiguous string representation.
+// ModuleFunc values also include their function pointer so distinct literals
+// remain distinct.
+func moduleIdentity(module Module) moduleKey {
 	modType := reflect.TypeOf(module)
+	key := moduleKey{typ: modType}
+
 	if modType == typeOfModuleFunc {
-		value := reflect.ValueOf(module)
-		return fmt.Sprintf("%s_%d", value.Type(), value.Pointer())
+		key.function = reflect.ValueOf(module).Pointer()
 	}
 
-	return qualifiedTypeName(modType)
+	return key
+}
+
+// moduleName returns the display name used in module graph diagnostics.
+func moduleName(module Module) string {
+	key := moduleIdentity(module)
+	if key.typ == typeOfModuleFunc {
+		return fmt.Sprintf("%s_%d", key.typ, key.function)
+	}
+
+	return qualifiedTypeName(key.typ)
 }
 
 // qualifiedTypeName is like reflect.Type.String but uses the full import path
 // instead of the short package name, preserving pointer markers. Unnamed types
 // (no import path) fall back to String.
 func qualifiedTypeName(t reflect.Type) string {
+	if t.PkgPath() != "" {
+		return t.PkgPath() + "." + t.Name()
+	}
+
 	if t.Kind() == reflect.Pointer {
 		return "*" + qualifiedTypeName(t.Elem())
 	}
 
-	if t.PkgPath() == "" {
-		return t.String()
-	}
-
-	return t.PkgPath() + "." + t.Name()
+	return t.String()
 }

--- a/module_identity_test.go
+++ b/module_identity_test.go
@@ -17,9 +17,30 @@ func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 		t.Fatalf("NewInjector: %v", err)
 	}
 
+	commerceConfigured := 0
+	om3Configured := 0
+	commerceModule := &commercecart.Module{
+		OnConfigure: func() {
+			commerceConfigured++
+		},
+	}
+	om3Module := &om3cart.Module{
+		OnConfigure: func() {
+			om3Configured++
+		},
+	}
+
 	// Both packages expose a cart.Module; both must be configured, not collapsed.
-	if err := injector.InitModules(new(commercecart.Module), new(om3cart.Module)); err != nil {
+	if err := injector.InitModules(commerceModule, commerceModule, om3Module, om3Module); err != nil {
 		t.Fatalf("InitModules: %v", err)
+	}
+
+	if commerceConfigured != 1 {
+		t.Fatalf("first same-named module configured %d times, want 1", commerceConfigured)
+	}
+
+	if om3Configured != 1 {
+		t.Fatalf("second same-named module configured %d times, want 1", om3Configured)
 	}
 
 	if _, err := injector.GetInstance((*commercecart.Service)(nil)); err != nil {
@@ -28,5 +49,33 @@ func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 
 	if _, err := injector.GetInstance((*om3cart.Service)(nil)); err != nil {
 		t.Fatalf("binding from the second same-named module was dropped: %v", err)
+	}
+}
+
+func TestInitModules_DistinctAnonymousModulesSameEmbeddedTypeName(t *testing.T) {
+	t.Parallel()
+
+	injector, err := dingo.NewInjector()
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+
+	commerceModule := &struct{ *commercecart.Module }{
+		Module: new(commercecart.Module),
+	}
+	om3Module := &struct{ *om3cart.Module }{
+		Module: new(om3cart.Module),
+	}
+
+	if err := injector.InitModules(commerceModule, om3Module); err != nil {
+		t.Fatalf("InitModules: %v", err)
+	}
+
+	if _, err := injector.GetInstance((*commercecart.Service)(nil)); err != nil {
+		t.Fatalf("binding from the first anonymous module was dropped: %v", err)
+	}
+
+	if _, err := injector.GetInstance((*om3cart.Service)(nil)); err != nil {
+		t.Fatalf("binding from the second anonymous module was dropped: %v", err)
 	}
 }

--- a/module_identity_test.go
+++ b/module_identity_test.go
@@ -1,0 +1,28 @@
+package dingo_test
+
+import (
+	"testing"
+
+	"flamingo.me/dingo"
+
+	commercecart "flamingo.me/dingo/testdata/moduleidentity/commerce/cart"
+	om3cart "flamingo.me/dingo/testdata/moduleidentity/om3/cart"
+)
+
+func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
+	t.Parallel()
+
+	injector, err := dingo.NewInjector()
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+
+	// Both packages expose a cart.Module; both must be configured, not collapsed.
+	if err := injector.InitModules(new(commercecart.Module), new(om3cart.Module)); err != nil {
+		t.Fatalf("InitModules: %v", err)
+	}
+
+	if _, err := injector.GetInstance((*om3cart.Service)(nil)); err != nil {
+		t.Fatalf("binding from the second same-named module was dropped: %v", err)
+	}
+}

--- a/module_identity_test.go
+++ b/module_identity_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type moduleWithDependencies struct {
+	dependencies []dingo.Module
+}
+
+func (*moduleWithDependencies) Configure(*dingo.Injector) {}
+
+func (module *moduleWithDependencies) Depends() []dingo.Module {
+	return module.dependencies
+}
+
 func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 	t.Parallel()
 
@@ -40,6 +50,26 @@ func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 
 	_, err = injector.GetInstance((*om3cart.Service)(nil))
 	require.NoError(t, err)
+}
+
+func TestInitModules_DistinctPackagesSameTypeNameAsDependencies(t *testing.T) {
+	t.Parallel()
+
+	injector, err := dingo.NewInjector()
+	require.NoError(t, err)
+
+	commerceConfigured := 0
+	om3Configured := 0
+	root := &moduleWithDependencies{
+		dependencies: []dingo.Module{
+			&commercecart.Module{OnConfigure: func() { commerceConfigured++ }},
+			&om3cart.Module{OnConfigure: func() { om3Configured++ }},
+		},
+	}
+
+	require.NoError(t, injector.InitModules(root))
+	assert.Equal(t, 1, commerceConfigured)
+	assert.Equal(t, 1, om3Configured)
 }
 
 func TestInitModules_DistinctAnonymousModulesSameEmbeddedTypeName(t *testing.T) {

--- a/module_identity_test.go
+++ b/module_identity_test.go
@@ -7,15 +7,15 @@ import (
 
 	commercecart "flamingo.me/dingo/testdata/moduleidentity/commerce/cart"
 	om3cart "flamingo.me/dingo/testdata/moduleidentity/om3/cart"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 	t.Parallel()
 
 	injector, err := dingo.NewInjector()
-	if err != nil {
-		t.Fatalf("NewInjector: %v", err)
-	}
+	require.NoError(t, err)
 
 	commerceConfigured := 0
 	om3Configured := 0
@@ -31,34 +31,22 @@ func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 	}
 
 	// Both packages expose a cart.Module; both must be configured, not collapsed.
-	if err := injector.InitModules(commerceModule, commerceModule, om3Module, om3Module); err != nil {
-		t.Fatalf("InitModules: %v", err)
-	}
+	require.NoError(t, injector.InitModules(commerceModule, commerceModule, om3Module, om3Module))
+	assert.Equal(t, 1, commerceConfigured)
+	assert.Equal(t, 1, om3Configured)
 
-	if commerceConfigured != 1 {
-		t.Fatalf("first same-named module configured %d times, want 1", commerceConfigured)
-	}
+	_, err = injector.GetInstance((*commercecart.Service)(nil))
+	require.NoError(t, err)
 
-	if om3Configured != 1 {
-		t.Fatalf("second same-named module configured %d times, want 1", om3Configured)
-	}
-
-	if _, err := injector.GetInstance((*commercecart.Service)(nil)); err != nil {
-		t.Fatalf("binding from the first same-named module was dropped: %v", err)
-	}
-
-	if _, err := injector.GetInstance((*om3cart.Service)(nil)); err != nil {
-		t.Fatalf("binding from the second same-named module was dropped: %v", err)
-	}
+	_, err = injector.GetInstance((*om3cart.Service)(nil))
+	require.NoError(t, err)
 }
 
 func TestInitModules_DistinctAnonymousModulesSameEmbeddedTypeName(t *testing.T) {
 	t.Parallel()
 
 	injector, err := dingo.NewInjector()
-	if err != nil {
-		t.Fatalf("NewInjector: %v", err)
-	}
+	require.NoError(t, err)
 
 	commerceModule := &struct{ *commercecart.Module }{
 		Module: new(commercecart.Module),
@@ -67,15 +55,11 @@ func TestInitModules_DistinctAnonymousModulesSameEmbeddedTypeName(t *testing.T) 
 		Module: new(om3cart.Module),
 	}
 
-	if err := injector.InitModules(commerceModule, om3Module); err != nil {
-		t.Fatalf("InitModules: %v", err)
-	}
+	require.NoError(t, injector.InitModules(commerceModule, om3Module))
 
-	if _, err := injector.GetInstance((*commercecart.Service)(nil)); err != nil {
-		t.Fatalf("binding from the first anonymous module was dropped: %v", err)
-	}
+	_, err = injector.GetInstance((*commercecart.Service)(nil))
+	require.NoError(t, err)
 
-	if _, err := injector.GetInstance((*om3cart.Service)(nil)); err != nil {
-		t.Fatalf("binding from the second anonymous module was dropped: %v", err)
-	}
+	_, err = injector.GetInstance((*om3cart.Service)(nil))
+	require.NoError(t, err)
 }

--- a/module_identity_test.go
+++ b/module_identity_test.go
@@ -22,6 +22,10 @@ func TestInitModules_DistinctPackagesSameTypeName(t *testing.T) {
 		t.Fatalf("InitModules: %v", err)
 	}
 
+	if _, err := injector.GetInstance((*commercecart.Service)(nil)); err != nil {
+		t.Fatalf("binding from the first same-named module was dropped: %v", err)
+	}
+
 	if _, err := injector.GetInstance((*om3cart.Service)(nil)); err != nil {
 		t.Fatalf("binding from the second same-named module was dropped: %v", err)
 	}

--- a/module_identity_test.go
+++ b/module_identity_test.go
@@ -48,14 +48,29 @@ func TestInitModules_DistinctAnonymousModulesSameEmbeddedTypeName(t *testing.T) 
 	injector, err := dingo.NewInjector()
 	require.NoError(t, err)
 
+	commerceConfigured := 0
+	om3Configured := 0
 	commerceModule := &struct{ *commercecart.Module }{
-		Module: new(commercecart.Module),
+		Module: &commercecart.Module{
+			OnConfigure: func() {
+				commerceConfigured++
+			},
+		},
 	}
 	om3Module := &struct{ *om3cart.Module }{
-		Module: new(om3cart.Module),
+		Module: &om3cart.Module{
+			OnConfigure: func() {
+				om3Configured++
+			},
+		},
 	}
 
+	// Both anonymous wrappers embed a same-named cart.Module from a different
+	// package. Both promoted Configure methods must run; if the two modules
+	// were collapsed into one, only one counter would be incremented.
 	require.NoError(t, injector.InitModules(commerceModule, om3Module))
+	assert.Equal(t, 1, commerceConfigured)
+	assert.Equal(t, 1, om3Configured)
 
 	_, err = injector.GetInstance((*commercecart.Service)(nil))
 	require.NoError(t, err)

--- a/module_test.go
+++ b/module_test.go
@@ -59,6 +59,30 @@ func TestResolveDependenciesWithModuleFunc(t *testing.T) {
 	assert.Equal(t, 1, countExtern, "variable defined modules should only be called once")
 }
 
+func TestResolveDependenciesWithModuleFuncClosures(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"first", "second", "third"}
+
+	var configured []string
+
+	modules := make([]Module, 0, len(names))
+
+	// Every closure shares the code pointer of this single func literal, but
+	// each captures a different name and is therefore a distinct module.
+	for _, name := range names {
+		modules = append(modules, ModuleFunc(func(*Injector) {
+			configured = append(configured, name)
+		}))
+	}
+
+	injector, err := NewInjector(modules...)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, injector)
+	assert.Equal(t, names, configured, "closures created from the same func literal must all be configured, in registration order")
+}
+
 type (
 	resolveDependenciesModuleA  struct{}
 	resolveDependenciesModuleB  struct{}

--- a/module_test.go
+++ b/module_test.go
@@ -1,6 +1,7 @@
 package dingo
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -196,6 +197,50 @@ func TestModGraph_Sorted(t *testing.T) {
 			if test.assertErr(t, err) {
 				assert.Equalf(t, test.sorted, sorted, "Sorted()")
 			}
+		})
+	}
+}
+
+type (
+	namedSlice   []int
+	namedPointer *int
+)
+
+func TestQualifiedTypeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want string
+	}{
+		{
+			name: "pointer to named struct",
+			typ:  reflect.TypeOf(&A{}),
+			want: "*flamingo.me/dingo.A",
+		},
+		{
+			name: "named slice",
+			typ:  reflect.TypeOf(namedSlice(nil)),
+			want: "flamingo.me/dingo.namedSlice",
+		},
+		{
+			name: "named pointer",
+			typ:  reflect.TypeOf(namedPointer(nil)),
+			want: "flamingo.me/dingo.namedPointer",
+		},
+		{
+			name: "builtin",
+			typ:  reflect.TypeOf(0),
+			want: "int",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, qualifiedTypeName(test.typ))
 		})
 	}
 }

--- a/module_test.go
+++ b/module_test.go
@@ -180,7 +180,7 @@ func TestModGraph_Sorted(t *testing.T) {
 			modules: []Module{&A{withCycle: true}, new(B), new(D), new(E)},
 			assertErr: assert.ErrorAssertionFunc(func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorIs(t, err, ErrModuleCycle) &&
-					assert.ErrorContains(t, err, "cyclic module dependency: *dingo.A → *dingo.C → *dingo.E")
+					assert.ErrorContains(t, err, "cyclic module dependency: *flamingo.me/dingo.A → *flamingo.me/dingo.C → *flamingo.me/dingo.E")
 			}),
 		},
 	}

--- a/module_test.go
+++ b/module_test.go
@@ -220,6 +220,11 @@ func TestQualifiedTypeName(t *testing.T) {
 			want: "*flamingo.me/dingo.A",
 		},
 		{
+			name: "double pointer to named struct",
+			typ:  reflect.TypeOf((**A)(nil)),
+			want: "**flamingo.me/dingo.A",
+		},
+		{
 			name: "named slice",
 			typ:  reflect.TypeOf(namedSlice(nil)),
 			want: "flamingo.me/dingo.namedSlice",
@@ -233,6 +238,46 @@ func TestQualifiedTypeName(t *testing.T) {
 			name: "builtin",
 			typ:  reflect.TypeOf(0),
 			want: "int",
+		},
+		{
+			name: "unnamed slice of builtin",
+			typ:  reflect.TypeOf([]int(nil)),
+			want: "[]int",
+		},
+		{
+			name: "unnamed slice of pointer to named struct",
+			typ:  reflect.TypeOf([]*A(nil)),
+			want: "[]*flamingo.me/dingo.A",
+		},
+		{
+			name: "unnamed array of pointer to named struct",
+			typ:  reflect.TypeOf([3]*A{}),
+			want: "[3]*flamingo.me/dingo.A",
+		},
+		{
+			name: "unnamed map with pointer to named struct value",
+			typ:  reflect.TypeOf(map[string]*A(nil)),
+			want: "map[string]*flamingo.me/dingo.A",
+		},
+		{
+			name: "unnamed bidirectional channel of pointer to named struct",
+			typ:  reflect.TypeOf(make(chan *A)),
+			want: "chan *flamingo.me/dingo.A",
+		},
+		{
+			name: "unnamed send-only channel of pointer to named struct",
+			typ:  reflect.TypeOf(make(chan<- *A)),
+			want: "chan<- *flamingo.me/dingo.A",
+		},
+		{
+			name: "unnamed receive-only channel of pointer to named struct",
+			typ:  reflect.TypeOf(make(<-chan *A)),
+			want: "<-chan *flamingo.me/dingo.A",
+		},
+		{
+			name: "anonymous struct falls back to Type.String",
+			typ:  reflect.TypeOf(struct{ X int }{}),
+			want: reflect.TypeOf(struct{ X int }{}).String(),
 		},
 	}
 

--- a/testdata/moduleidentity/commerce/cart/module.go
+++ b/testdata/moduleidentity/commerce/cart/module.go
@@ -10,8 +10,14 @@ type serviceImpl struct{}
 
 func (serviceImpl) Marker() {}
 
-type Module struct{}
+type Module struct {
+	OnConfigure func()
+}
 
-func (*Module) Configure(injector *dingo.Injector) {
+func (module *Module) Configure(injector *dingo.Injector) {
+	if module.OnConfigure != nil {
+		module.OnConfigure()
+	}
+
 	injector.Bind((*Service)(nil)).To(serviceImpl{})
 }

--- a/testdata/moduleidentity/commerce/cart/module.go
+++ b/testdata/moduleidentity/commerce/cart/module.go
@@ -1,0 +1,7 @@
+package cart
+
+import "flamingo.me/dingo"
+
+type Module struct{}
+
+func (*Module) Configure(*dingo.Injector) {}

--- a/testdata/moduleidentity/commerce/cart/module.go
+++ b/testdata/moduleidentity/commerce/cart/module.go
@@ -2,6 +2,16 @@ package cart
 
 import "flamingo.me/dingo"
 
+type Service interface {
+	Marker()
+}
+
+type serviceImpl struct{}
+
+func (serviceImpl) Marker() {}
+
 type Module struct{}
 
-func (*Module) Configure(*dingo.Injector) {}
+func (*Module) Configure(injector *dingo.Injector) {
+	injector.Bind((*Service)(nil)).To(serviceImpl{})
+}

--- a/testdata/moduleidentity/commerce/cart/module.go
+++ b/testdata/moduleidentity/commerce/cart/module.go
@@ -1,3 +1,4 @@
+// Intentionally identical to om3/cart so Type.String() collides while reflect.Type does not.
 package cart
 
 import "flamingo.me/dingo"

--- a/testdata/moduleidentity/om3/cart/module.go
+++ b/testdata/moduleidentity/om3/cart/module.go
@@ -1,0 +1,17 @@
+package cart
+
+import "flamingo.me/dingo"
+
+type Service interface {
+	Marker()
+}
+
+type serviceImpl struct{}
+
+func (serviceImpl) Marker() {}
+
+type Module struct{}
+
+func (*Module) Configure(injector *dingo.Injector) {
+	injector.Bind((*Service)(nil)).To(serviceImpl{})
+}

--- a/testdata/moduleidentity/om3/cart/module.go
+++ b/testdata/moduleidentity/om3/cart/module.go
@@ -1,3 +1,4 @@
+// Intentionally identical to commerce/cart so Type.String() collides while reflect.Type does not.
 package cart
 
 import "flamingo.me/dingo"

--- a/testdata/moduleidentity/om3/cart/module.go
+++ b/testdata/moduleidentity/om3/cart/module.go
@@ -10,8 +10,14 @@ type serviceImpl struct{}
 
 func (serviceImpl) Marker() {}
 
-type Module struct{}
+type Module struct {
+	OnConfigure func()
+}
 
-func (*Module) Configure(injector *dingo.Injector) {
+func (module *Module) Configure(injector *dingo.Injector) {
+	if module.OnConfigure != nil {
+		module.OnConfigure()
+	}
+
 	injector.Bind((*Service)(nil)).To(serviceImpl{})
 }


### PR DESCRIPTION
## Problem

The module graph used `reflect.Type.String()` as its key. That string can omit import paths, so same-named modules from different packages could collide. The second module was skipped with its bindings.

`ModuleFunc` values were keyed by code pointer. Closures created from one function literal share that pointer, so later closures could also be skipped.

## Changes

- Key regular modules by exact `reflect.Type`.
- Key `ModuleFunc` by `reflect.Value`, restoring the behavior from before the module graph.
- Use import-qualified type names only in cycle errors.

## Tests

- Same-named modules passed directly and through `Depends`.
- Anonymous modules with colliding type strings.
- Duplicate modules configure once and bindings from both packages resolve.
- Closures from one function literal stay distinct.
- Qualified names used in diagnostics.