### PR TITLE
fix: DIGIHUB-374210 fix moduleIdentity()

### DIFF
--- a/dingo.go
+++ b/dingo.go
@@ -725,7 +725,7 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 
 		i++
 
-		if ctype.Kind() != reflect.Ptr && current.MethodByName("Inject").IsValid() {
+		if ctype.Kind() != reflect.Pointer && current.MethodByName("Inject").IsValid() {
 			return fmt.Errorf("invalid inject receiver %s: %w", current, ErrInvalidInjectReceiver)
 		}
 
@@ -778,7 +778,7 @@ func (injector *Injector) requestInjection(object interface{}, circularTrace []c
 
 						field.Set(instance.Elem())
 					} else {
-						if field.Kind() == reflect.Ptr && field.Type().Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Interface {
+						if field.Kind() == reflect.Pointer && field.Type().Kind() == reflect.Pointer && field.Type().Elem().Kind() == reflect.Interface {
 							return wrapErr(fmt.Errorf("field %#v is pointer to interface. %w", currentFieldName, errPointersToInterface))
 						}
 

--- a/internal/collisiontest/pkgone/module.go
+++ b/internal/collisiontest/pkgone/module.go
@@ -1,0 +1,19 @@
+// Package oauth is a test helper whose package name intentionally collides
+// with internal/collisiontest/pkgtwo so that both declare a Module type whose
+// reflect.Type.String() renders identically (e.g. "*oauth.Module").
+package oauth
+
+import "flamingo.me/dingo"
+
+// Configured counts how often Module.Configure was called.
+var Configured int
+
+// Module is a dingo Module used to reproduce cross-package name collisions in
+// moduleIdentity tests.
+type Module struct{}
+
+// Configure records that it ran so a test can assert the module was not
+// deduplicated away.
+func (*Module) Configure(injector *dingo.Injector) {
+	Configured++
+}

--- a/internal/collisiontest/pkgtwo/module.go
+++ b/internal/collisiontest/pkgtwo/module.go
@@ -1,0 +1,19 @@
+// Package oauth is a test helper whose package name intentionally collides
+// with internal/collisiontest/pkgtwo so that both declare a Module type whose
+// reflect.Type.String() renders identically (e.g. "*oauth.Module").
+package oauth
+
+import "flamingo.me/dingo"
+
+// Configured counts how often Module.Configure was called.
+var Configured int
+
+// Module is a dingo Module used to reproduce cross-package name collisions in
+// moduleIdentity tests.
+type Module struct{}
+
+// Configure records that it ran so a test can assert the module was not
+// deduplicated away.
+func (*Module) Configure(injector *dingo.Injector) {
+	Configured++
+}

--- a/module.go
+++ b/module.go
@@ -223,23 +223,23 @@ func moduleIdentity(module Module) string {
 // identity. Anonymous composite types (pointer, slice, array, map, channel)
 // have no package path; their element types are qualified recursively so that
 // e.g. a bare *oauth.Module resolves through the named element.
-func qualifiedTypeName(t reflect.Type) string {
-	if pkgPath := t.PkgPath(); pkgPath != "" {
-		return pkgPath + "." + t.Name()
+func qualifiedTypeName(typ reflect.Type) string {
+	if pkgPath := typ.PkgPath(); pkgPath != "" {
+		return pkgPath + "." + typ.Name()
 	}
 
-	switch t.Kind() {
+	switch typ.Kind() { //nolint:exhaustive // default branch handles all remaining kinds
 	case reflect.Pointer:
-		return "*" + qualifiedTypeName(t.Elem())
+		return "*" + qualifiedTypeName(typ.Elem())
 	case reflect.Slice:
-		return "[]" + qualifiedTypeName(t.Elem())
+		return "[]" + qualifiedTypeName(typ.Elem())
 	case reflect.Array:
-		return fmt.Sprintf("[%d]%s", t.Len(), qualifiedTypeName(t.Elem()))
+		return fmt.Sprintf("[%d]%s", typ.Len(), qualifiedTypeName(typ.Elem()))
 	case reflect.Map:
-		return "map[" + qualifiedTypeName(t.Key()) + "]" + qualifiedTypeName(t.Elem())
+		return "map[" + qualifiedTypeName(typ.Key()) + "]" + qualifiedTypeName(typ.Elem())
 	case reflect.Chan:
-		return t.ChanDir().String() + " " + qualifiedTypeName(t.Elem())
+		return typ.ChanDir().String() + " " + qualifiedTypeName(typ.Elem())
+	default:
+		return typ.String()
 	}
-
-	return t.String()
 }

--- a/module.go
+++ b/module.go
@@ -217,10 +217,17 @@ func moduleIdentity(module Module) string {
 // qualifiedTypeName returns a globally unique name for the given type by
 // combining its package import path with its type name. This distinguishes
 // identically named types declared in different packages, which
-// reflect.Type.String() (e.g. "*oauth.Module") does not. Pointer, slice,
-// array, map and channel wrappers are preserved so their element types are
-// qualified recursively.
+// reflect.Type.String() (e.g. "*oauth.Module") does not. Named defined types
+// are qualified by their own package path and name, so a named type whose
+// underlying kind is a composite (e.g. type Modules []Module) keeps its own
+// identity. Anonymous composite types (pointer, slice, array, map, channel)
+// have no package path; their element types are qualified recursively so that
+// e.g. a bare *oauth.Module resolves through the named element.
 func qualifiedTypeName(t reflect.Type) string {
+	if pkgPath := t.PkgPath(); pkgPath != "" {
+		return pkgPath + "." + t.Name()
+	}
+
 	switch t.Kind() {
 	case reflect.Pointer:
 		return "*" + qualifiedTypeName(t.Elem())
@@ -232,10 +239,6 @@ func qualifiedTypeName(t reflect.Type) string {
 		return "map[" + qualifiedTypeName(t.Key()) + "]" + qualifiedTypeName(t.Elem())
 	case reflect.Chan:
 		return t.ChanDir().String() + " " + qualifiedTypeName(t.Elem())
-	}
-
-	if pkgPath := t.PkgPath(); pkgPath != "" {
-		return pkgPath + "." + t.Name()
 	}
 
 	return t.String()

--- a/module.go
+++ b/module.go
@@ -211,5 +211,32 @@ func moduleIdentity(module Module) string {
 		return fmt.Sprintf("%s_%d", value.Type(), value.Pointer())
 	}
 
-	return modType.String()
+	return qualifiedTypeName(modType)
+}
+
+// qualifiedTypeName returns a globally unique name for the given type by
+// combining its package import path with its type name. This distinguishes
+// identically named types declared in different packages, which
+// reflect.Type.String() (e.g. "*oauth.Module") does not. Pointer, slice,
+// array, map and channel wrappers are preserved so their element types are
+// qualified recursively.
+func qualifiedTypeName(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Pointer:
+		return "*" + qualifiedTypeName(t.Elem())
+	case reflect.Slice:
+		return "[]" + qualifiedTypeName(t.Elem())
+	case reflect.Array:
+		return fmt.Sprintf("[%d]%s", t.Len(), qualifiedTypeName(t.Elem()))
+	case reflect.Map:
+		return "map[" + qualifiedTypeName(t.Key()) + "]" + qualifiedTypeName(t.Elem())
+	case reflect.Chan:
+		return t.ChanDir().String() + " " + qualifiedTypeName(t.Elem())
+	}
+
+	if pkgPath := t.PkgPath(); pkgPath != "" {
+		return pkgPath + "." + t.Name()
+	}
+
+	return t.String()
 }

--- a/module_collision_test.go
+++ b/module_collision_test.go
@@ -18,6 +18,8 @@ import (
 // that string silently dropped one of them, so its Configure never ran. Both
 // modules must be initialized.
 func TestNewInjector_SameShortNameDifferentPackages(t *testing.T) {
+	t.Parallel()
+
 	pkgone.Configured = 0
 	pkgtwo.Configured = 0
 

--- a/module_collision_test.go
+++ b/module_collision_test.go
@@ -1,0 +1,30 @@
+package dingo_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"flamingo.me/dingo"
+	pkgone "flamingo.me/dingo/internal/collisiontest/pkgone"
+	pkgtwo "flamingo.me/dingo/internal/collisiontest/pkgtwo"
+)
+
+// TestNewInjector_SameShortNameDifferentPackages guards against the
+// moduleIdentity() collision fixed in DIGIHUB-374210: two Module types that
+// live in different packages but share the same package name render
+// identically via reflect.Type.String() ("*oauth.Module"). Keying modules by
+// that string silently dropped one of them, so its Configure never ran. Both
+// modules must be initialized.
+func TestNewInjector_SameShortNameDifferentPackages(t *testing.T) {
+	pkgone.Configured = 0
+	pkgtwo.Configured = 0
+
+	injector, err := dingo.NewInjector(new(pkgone.Module), new(pkgtwo.Module))
+
+	require.NoError(t, err)
+	require.NotNil(t, injector)
+	assert.Equal(t, 1, pkgone.Configured, "pkgone.Module must not be deduplicated away")
+	assert.Equal(t, 1, pkgtwo.Configured, "pkgtwo.Module must not be deduplicated away")
+}

--- a/module_test.go
+++ b/module_test.go
@@ -1,6 +1,7 @@
 package dingo
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -196,6 +197,59 @@ func TestModGraph_Sorted(t *testing.T) {
 			if test.assertErr(t, err) {
 				assert.Equalf(t, test.sorted, sorted, "Sorted()")
 			}
+		})
+	}
+}
+
+// namedSlice and namedPointer are named defined types whose underlying kind is
+// a composite. qualifiedTypeName must key them by their own package path and
+// name rather than unwrapping to the structural form, otherwise two distinct
+// named wrapper types over the same element would collide.
+type (
+	namedSlice   []int
+	namedPointer *int
+)
+
+func TestQualifiedTypeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want string
+	}{
+		{
+			name: "pointer to named struct is qualified through element",
+			typ:  reflect.TypeOf(&A{}),
+			want: "*flamingo.me/dingo.A",
+		},
+		{
+			name: "named slice keeps its own identity",
+			typ:  reflect.TypeOf(namedSlice(nil)),
+			want: "flamingo.me/dingo.namedSlice",
+		},
+		{
+			name: "named pointer keeps its own identity",
+			typ:  reflect.TypeOf(namedPointer(nil)),
+			want: "flamingo.me/dingo.namedPointer",
+		},
+		{
+			name: "anonymous slice of named type is qualified through element",
+			typ:  reflect.TypeOf([]A{}),
+			want: "[]flamingo.me/dingo.A",
+		},
+		{
+			name: "builtin type falls back to String",
+			typ:  reflect.TypeOf(0),
+			want: "int",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, qualifiedTypeName(test.typ))
 		})
 	}
 }

--- a/module_test.go
+++ b/module_test.go
@@ -180,7 +180,7 @@ func TestModGraph_Sorted(t *testing.T) {
 			modules: []Module{&A{withCycle: true}, new(B), new(D), new(E)},
 			assertErr: assert.ErrorAssertionFunc(func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorIs(t, err, ErrModuleCycle) &&
-					assert.ErrorContains(t, err, "cyclic module dependency: *dingo.A → *dingo.C → *dingo.E")
+					assert.ErrorContains(t, err, "cyclic module dependency: *flamingo.me/dingo.A → *flamingo.me/dingo.C → *flamingo.me/dingo.E")
 			}),
 		},
 	}


### PR DESCRIPTION
**Problem**

Since v0.4.0, dingo's module dedup/ordering logic ( resolveDependencies  → topological  modGraph ) keys modules by  reflect.Type.String()  in  moduleIdentity()  — e.g.  "*oauth.Module" . That string is not unique across packages, so two different  Module  types that stringify identically are treated as the same module, and one of each pair is silently dropped.

In practice this dropped flamingo's  core/auth/oauth.Module  vs.  shared/v2/oauth.Module  (and  core/security  vs.  shared/v2/security ). The dropped  shared/v2/oauth.Module.Configure  never ran its  BindMap , so flamingo's  buildAuthentifier  panicked at bootstrap:

panic: unknown broker gigabit.oauth.faketbsbroker

**Fix**

 moduleIdentity()  now derives its key from a new  qualifiedTypeName()  helper that builds a globally unique key from  PkgPath() + "." + Name()  instead of  String() . Because module values are pointers (e.g.  *oauth.Module ), the helper recursively unwraps pointer/slice/array/map/chan wrappers so the underlying element type is properly qualified (a bare pointer type has empty  PkgPath() / Name() ).

This resolves the whole class of same-named- Module  collisions generically, rather than requiring every consumer to rename its types.

**Changes**

•  module.go : add  qualifiedTypeName() ;  moduleIdentity()  uses it for non- ModuleFunc  types.
•  module_test.go : update the cycle-error assertion to the new fully-qualified format ( *flamingo.me/dingo.A → *flamingo.me/dingo.C → *flamingo.me/dingo.E ).

**Validation**

 go build ./... ,  go test ./... ,  go vet ./... , and  gofmt  all pass.